### PR TITLE
Align variable names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn broker(mut incoming: Receiver<ClientEvent>) {
             ClientEvent::Connect(c) => { broker.clients.insert(c.name.clone(), c); },
             ClientEvent::Message { name: sender_name, msg } => {
                 for (_, c) in broker.clients.iter().filter(|(name, _)| **name != sender_name) {
-                    c.sender.send(format!("{}: {}\n", sender_name, msg)).await 
+                    c.sender.send(format!("{}: {}\n", sender_name, msg)).await
                 }
             },
             ClientEvent::Disconnect { name } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn broker(mut incoming: Receiver<ClientEvent>) {
     }
 }
 
-async fn client(mut stream: TcpStream, broker_connection: Sender<ClientEvent>) -> io::Result<()> {
+async fn client_handler(mut stream: TcpStream, broker_sender: Sender<ClientEvent>) -> io::Result<()> {
 
     // Accept a client
     // read its name line


### PR DESCRIPTION
While working on this exercise, I struggled with the variable names a bit:

- `client()` sounds like it is supposed to implement a chat client, while its task is actually setting up the connection broker and client (at least that's how I understood and implemented it)
- `broker_connection` is named differently in the function signature of `client()` and its creation in line 71 (i.e. `let (broker_sender, broker_receiver) = channel(10);`), plus the name doesn't indicate which way the connection goes

This PR is a proposal to improve this.